### PR TITLE
BUGFIX: now refreshing team list after new match is added

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Recon",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/src/ui/match/add.js
+++ b/src/ui/match/add.js
@@ -17,6 +17,7 @@ import {
   AllianceToggle,
   Comments
 } from './components';
+import { refreshTeamList } from '../actions';
 import MatchService from '../../services/match-service';
 import TeamService from '../../services/team-service';
 import TournamentService from '../../services/tournament-service';
@@ -121,6 +122,7 @@ export default class MatchAdd extends Component {
 
     return matchService.create(matchToSave)
       .then(() => {
+        refreshTeamList();
         this.props.navigation.state.params.refresh();
         this.props.navigation.goBack();
       })


### PR DESCRIPTION
Description
====
fixes issue where adding a new match would not result in new statistics being calculated for the team list tiles.

PR Checklist
====
- [x] Validated on phone
- [x] Validated on tablet
- [x] Updated version
